### PR TITLE
Lock NLog version 

### DIFF
--- a/ripple.config
+++ b/ripple.config
@@ -14,7 +14,7 @@
   <Nugets>
     <Dependency Name="FubuTestingSupport" Version="1.1.0.257" Mode="Float" />
     <Dependency Name="ILRepack" Version="1.22.2.0" Mode="Float" />
-    <Dependency Name="NLog" Version="2.1.0.0" Mode="Float" />
+    <Dependency Name="NLog" Version="2.1.0.0" Mode="Fixed" />
     <Dependency Name="NUnit" Version="2.5.10.11092" Mode="Fixed" />
     <Dependency Name="RhinoMocks" Version="3.6.1" Mode="Fixed" />
     <Dependency Name="structuremap" Version="2.6.4.79" Mode="Fixed" />


### PR DESCRIPTION
Lock NLog version so that we don't depend on NLog 3.0 before we are ready
