### PR TITLE
introduce queue interface

### DIFF
--- a/src/LightningQueues.Benchmarks/SendAndReceive.cs
+++ b/src/LightningQueues.Benchmarks/SendAndReceive.cs
@@ -22,8 +22,8 @@ public enum StorageMode
 [MemoryDiagnoser]
 public class SendAndReceive
 {
-    private Queue? _sender;
-    private Queue? _receiver;
+    private IQueue? _sender;
+    private IQueue? _receiver;
     private Message[]? _messages;
     private Task? _receivingTask;
 

--- a/src/LightningQueues.Tests/QueueConfigurationExtensions.cs
+++ b/src/LightningQueues.Tests/QueueConfigurationExtensions.cs
@@ -81,7 +81,7 @@ public static class QueueConfigurationExtensions
         return configuration;
     }
     
-    public static Queue BuildAndStartQueue(this QueueConfiguration configuration, params string[] queues)
+    public static IQueue BuildAndStartQueue(this QueueConfiguration configuration, params string[] queues)
     {
         var queue = configuration.BuildQueue();
         foreach (var queueName in queues)

--- a/src/LightningQueues.Tests/TestBase.cs
+++ b/src/LightningQueues.Tests/TestBase.cs
@@ -42,7 +42,7 @@ public class TestBase
    }
 
    protected async Task QueueScenario(Action<QueueConfiguration> queueBuilder,
-      Func<Queue, CancellationToken, Task> scenario, TimeSpan timeout, string queueName = "test")
+      Func<IQueue, CancellationToken, Task> scenario, TimeSpan timeout, string queueName = "test")
    {
       using var cancellation = new CancellationTokenSource(timeout);
       var serializer = new MessageSerializer();
@@ -58,18 +58,18 @@ public class TestBase
    }
    
    protected Task QueueScenario(Action<QueueConfiguration> queueBuilder,
-      Func<Queue, CancellationToken, Task> scenario, string queueName = "test")
+      Func<IQueue, CancellationToken, Task> scenario, string queueName = "test")
    {
       return QueueScenario(queueBuilder, scenario, TimeSpan.FromSeconds(1), queueName);
    }
 
-   protected Task QueueScenario(Func<Queue, CancellationToken, Task> scenario, TimeSpan timeout,
+   protected Task QueueScenario(Func<IQueue, CancellationToken, Task> scenario, TimeSpan timeout,
       string queueName = "test")
    {
       return QueueScenario(config => { }, scenario, timeout, queueName);
    }
 
-   protected Task QueueScenario(Func<Queue, CancellationToken, Task> scenario, string queueName = "test")
+   protected Task QueueScenario(Func<IQueue, CancellationToken, Task> scenario, string queueName = "test")
    {
       return QueueScenario(scenario, TimeSpan.FromSeconds(1), queueName);
    }

--- a/src/LightningQueues/IQueue.cs
+++ b/src/LightningQueues/IQueue.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using LightningQueues.Storage;
+
+namespace LightningQueues;
+
+/// <summary>
+/// Defines the interface for a message queue that can send and receive messages across the network.
+/// </summary>
+public interface IQueue : IDisposable, IAsyncDisposable
+{
+    /// <summary>
+    /// Gets the message store used by this queue for persistence.
+    /// </summary>
+    public IMessageStore Store { get; }
+
+    /// <summary>
+    /// Gets an array of all queue names available in this queue instance.
+    /// </summary>
+    public string[] Queues { get; }
+
+    /// <summary>
+    /// Gets the network endpoint where this queue is listening for incoming messages.
+    /// </summary>
+    public IPEndPoint Endpoint { get; }
+
+    /// <summary>
+    /// Creates a new queue with the specified name.
+    /// </summary>
+    /// <param name="queueName">The name of the queue to create.</param>
+    public void CreateQueue(string queueName);
+
+    /// <summary>
+    /// Starts the queue's processing operations.
+    /// </summary>
+    public void Start();
+
+    /// <summary>
+    /// Receives messages from the specified queue as an asynchronous stream.
+    /// </summary>
+    /// <param name="queueName">The name of the queue to receive messages from.</param>
+    /// <param name="pollIntervalInMilliseconds">The period to rest before checking for new messages if no messages are found.</param>
+    /// <param name="cancellationToken">A token to cancel the receive operation.</param>
+    /// <returns>An asynchronous stream of <see cref="MessageContext"/> objects.</returns>
+    public IAsyncEnumerable<MessageContext> Receive(string queueName, int pollIntervalInMilliseconds = 200,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Schedules a message to be available for processing after a specified delay.
+    /// </summary>
+    /// <param name="message">The message to delay.</param>
+    /// <param name="timeSpan">The time to delay processing of the message.</param>
+    public void ReceiveLater(Message message, TimeSpan timeSpan);
+
+    /// <summary>
+    /// Schedules a message to be available for processing at a specific time.
+    /// </summary>
+    /// <param name="message">The message to delay.</param>
+    /// <param name="time">The time when the message should become available.</param>
+    public void ReceiveLater(Message message, DateTimeOffset time);
+
+    /// <summary>
+    /// Moves a message from its current queue to another queue.
+    /// </summary>
+    /// <param name="queueName">The name of the target queue.</param>
+    /// <param name="message">The message to move.</param>
+    public void MoveToQueue(string queueName, Message message);
+
+    /// <summary>
+    /// Sends multiple messages to their respective destinations.
+    /// </summary>
+    /// <param name="messages">An array of messages to send.</param>
+    public void Send(params Message[] messages);
+
+    /// <summary>
+    /// Sends a single message to its destination.
+    /// </summary>
+    /// <param name="message">The message to send.</param>
+    public void Send(Message message);
+
+    /// <summary>
+    /// Adds a message directly to a queue for local processing.
+    /// </summary>
+    /// <param name="message">The message to enqueue.</param>
+    public void Enqueue(Message message);
+}

--- a/src/LightningQueues/Queue.cs
+++ b/src/LightningQueues/Queue.cs
@@ -17,7 +17,7 @@ namespace LightningQueues;
 /// Queue handles the core messaging operations including message sending, receiving,
 /// storage, and routing.
 /// </summary>
-public class Queue : IDisposable, IAsyncDisposable
+public class Queue : IQueue
 {
     private readonly Sender _sender;
     private readonly Receiver _receiver;

--- a/src/LightningQueues/QueueConfiguration.cs
+++ b/src/LightningQueues/QueueConfiguration.cs
@@ -235,7 +235,7 @@ public class QueueConfiguration
     /// The queue is created but not started. Call Start() on the returned queue
     /// to begin message processing.
     /// </remarks>
-    public Queue BuildQueue()
+    public IQueue BuildQueue()
     {
         if (_store == null)
             throw new ArgumentNullException(nameof(_store), "Storage has not been configured. Are you missing a call to StoreMessagesWith?");
@@ -273,7 +273,7 @@ public class QueueConfiguration
     /// 
     /// The queue is ready to send and receive messages immediately after this call.
     /// </remarks>
-    public Queue BuildAndStart(string queueName)
+    public IQueue BuildAndStart(string queueName)
     {
         var queue = BuildQueue();
         queue.CreateQueue(queueName);


### PR DESCRIPTION
**Summary**
Introduced an IQueue abstraction that fully matches the public surface of Queue, with XML documentation added for the interface and all members. This sets the foundation for building an OpenTelemetry wrapper around queue operations, making it possible to add observability without changing existing queue behavior.
**Why**
This interface was introduced so the queue implementation can be wrapped with OpenTelemetry instrumentation later, enabling observability on top of the existing queue functionality without disrupting current behavior.
**Verification**
Confirmed that Queue correctly implements the updated IQueue interface.
Ran the existing unit tests in QueueTests.cs.
All 10 tests passed successfully.